### PR TITLE
Fix plugin mermaid path

### DIFF
--- a/plugin/remark-mermaid/utils.js
+++ b/plugin/remark-mermaid/utils.js
@@ -64,7 +64,9 @@ export const renderFromFile = (inputFile, destination) => {
  * @return {string}
  */
 export const getDestinationDir = (vFile) => {
-  return path.join(path.resolve(), '/public/assets/images')
+  // Use project root as base. path.join with an absolute path would discard
+  // previous segments, so avoid leading slashes.
+  return path.join(path.resolve(), 'public', 'assets', 'images');
   // return vFile.data.destinationDir ?? vFile.dirname;
 }
 


### PR DESCRIPTION
## Summary
- fix mermaid output directory path

## Testing
- `prettier --write plugin/remark-mermaid/utils.js` *(fails: Cannot find package 'prettier-plugin-astro')*
