### PR TITLE
feat: add presentation video to about page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -210,6 +210,31 @@ import { dateRange } from "@lib/utils";
       </section>
 
       <section class="animate space-y-6">
+        <div class="flex flex-wrap gap-y-2 items-center justify-between">
+          <h5 class="font-semibold text-black">
+            Presentations
+          </h5>
+        </div>
+        <div class="space-y-4">
+          <figure class="w-full flex flex-col my-4">
+            <div
+              class="w-full block aspect-video border-0 bg-black rounded-lg shadow-[0px_0px_12px_6px_rgba(0,0,0,0.36)] overflow-hidden m-0"
+            >
+              <iframe
+                class="w-full aspect-video border-0"
+                src="https://www.youtube.com/embed/zrAGRppDkSw"
+                title="YouTube video player"
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                referrerpolicy="strict-origin-when-cross-origin"
+                loading="lazy"
+                allowfullscreen></iframe>
+            </div>
+          </figure>
+        </div>
+      </section>
+
+      <section class="animate space-y-6">
         <h5 class="font-semibold text-black">
           YouTube Channel
         </h5>


### PR DESCRIPTION
Added new Presentations section with embedded YouTube video between OSS Contributions and YouTube Channel sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)