### PR TITLE
feat: DD interaction refinements + LinkPreview fix

### DIFF
--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -3,25 +3,28 @@ import {
   motion,
   useMotionValue,
   useTransform,
+  useReducedMotion,
   type PanInfo,
 } from "framer-motion";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
 // --- Spring configs (DD: simulating-physics) ---
+// Close is snappier than open (DD: "exit should be faster than entry")
 const OPEN_SPRING = { type: "spring" as const, stiffness: 300, damping: 30 };
 const CLOSE_SPRING = { type: "spring" as const, stiffness: 500, damping: 35 };
+const INSTANT = { duration: 0 };
 
 // --- Thresholds ---
 const VELOCITY_DISMISS = 500; // px/s — fast drag dismisses immediately
 const DISTANCE_DISMISS = 150; // px — slow drag past this distance dismisses
+const DRAG_THRESHOLD = 3; // px — movement threshold before drag registers (DD: gesture conflicts)
 
-// --- Rubber banding (DD: rubber-banding dampen function) ---
+// --- Rubber banding (DD: dampen function) ---
 function dampen(val: number, max: number): number {
   const abs = Math.abs(val);
   if (abs > max) {
     const extra = abs - max;
-    const dampenedExtra = Math.sqrt(extra) * 3;
-    return Math.sign(val) * (max + dampenedExtra);
+    return Math.sign(val) * (max + Math.sqrt(extra) * 3);
   }
   return val;
 }
@@ -31,10 +34,10 @@ const gesture = {
   start: () => {
     document.body.style.cursor = "grabbing";
     document.body.style.userSelect = "none";
-    // Disable pointer events on everything else during drag
     const style = document.createElement("style");
     style.id = "lightbox-gesture";
-    style.textContent = "body > *:not(#lightbox-overlay) { pointer-events: none !important; }";
+    style.textContent =
+      "body > *:not(#lightbox-overlay) { pointer-events: none !important; }";
     document.head.appendChild(style);
   },
   end: () => {
@@ -44,62 +47,71 @@ const gesture = {
   },
 };
 
-interface LightboxImage {
-  src: string;
-  alt: string;
-  rect: DOMRect;
-}
-
 export function ImageLightbox() {
-  const [activeImage, setActiveImage] = useState<LightboxImage | null>(null);
+  const [activeImage, setActiveImage] = useState<{
+    src: string;
+    alt: string;
+  } | null>(null);
   const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const prefersReducedMotion = useReducedMotion();
 
   // Drag motion values
   const dragY = useMotionValue(0);
   const dragX = useMotionValue(0);
-
-  // Opacity linked to drag distance
   const dragDistance = useMotionValue(0);
-  const overlayOpacity = useTransform(dragDistance, [0, DISTANCE_DISMISS * 2], [1, 0.2]);
 
-  // Scale linked to drag distance for tactile feedback
-  const imageScale = useTransform(dragDistance, [0, DISTANCE_DISMISS * 2], [1, 0.85]);
+  // Interpolation: overlay opacity + image scale from drag distance (DD: responsive-interfaces)
+  const overlayOpacity = useTransform(
+    dragDistance,
+    [0, DISTANCE_DISMISS * 2],
+    [1, 0.2]
+  );
+  const imageScale = useTransform(
+    dragDistance,
+    [0, DISTANCE_DISMISS * 2],
+    [1, 0.85]
+  );
 
-  const isDragging = useRef(false);
+  const dragStarted = useRef(false); // Tracks if threshold was exceeded
+
+  // Animation config respecting reduced motion
+  const openTransition = prefersReducedMotion ? INSTANT : OPEN_SPRING;
+  const closeTransition = prefersReducedMotion ? INSTANT : CLOSE_SPRING;
 
   // Open lightbox
-  const openLightbox = useCallback((img: HTMLImageElement) => {
-    const rect = img.getBoundingClientRect();
-    setActiveImage({
-      src: img.src,
-      alt: img.alt || "",
-      rect,
-    });
-    setIsOpen(true);
-    document.body.style.overflow = "hidden";
-  }, []);
+  const openLightbox = useCallback(
+    (img: HTMLImageElement) => {
+      setActiveImage({
+        src: img.src,
+        alt: img.alt || "",
+      });
+      setIsOpen(true);
+      document.documentElement.style.overflow = "hidden";
+    },
+    []
+  );
 
   // Close lightbox
   const closeLightbox = useCallback(() => {
     setIsOpen(false);
-    document.body.style.overflow = "";
+    document.documentElement.style.overflow = "";
     gesture.end();
-    // Clean up after exit animation
+    // Use onAnimationComplete instead of setTimeout where possible,
+    // but AnimatePresence exit needs time — 300ms is conservative for spring
+    const cleanupDelay = prefersReducedMotion ? 0 : 300;
     setTimeout(() => {
       setActiveImage(null);
       dragY.jump(0);
       dragX.jump(0);
       dragDistance.jump(0);
-    }, 400);
-  }, [dragY, dragX, dragDistance]);
+    }, cleanupDelay);
+  }, [dragY, dragX, dragDistance, prefersReducedMotion]);
 
   // Esc key handler
   useEffect(() => {
+    if (!isOpen) return;
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape" && isOpen) {
-        closeLightbox();
-      }
+      if (e.key === "Escape") closeLightbox();
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
@@ -113,19 +125,17 @@ export function ImageLightbox() {
     const imgs = postContent.querySelectorAll("img");
 
     function handleClick(e: Event) {
+      e.preventDefault();
+      e.stopPropagation();
       const img = e.currentTarget as HTMLImageElement;
-      // Don't open for tiny images (icons, etc.)
       if (img.naturalWidth < 100 || img.naturalHeight < 100) return;
       openLightbox(img);
     }
 
     imgs.forEach((img) => {
       img.addEventListener("click", handleClick);
+      // DD: ergonomic-interactions — cursor affordance
       img.style.cursor = "zoom-in";
-      // Fitts' Law: expand hit area with padding (DD: ergonomic-interactions)
-      img.style.padding = "8px";
-      img.style.margin = "-8px";
-      img.style.boxSizing = "content-box";
     });
 
     return () => {
@@ -135,25 +145,26 @@ export function ImageLightbox() {
     };
   }, [openLightbox]);
 
-  // --- Drag handlers ---
+  // --- Drag handlers with threshold (DD: gesture conflicts) ---
   const onPanStart = useCallback(() => {
-    isDragging.current = true;
-    gesture.start();
+    dragStarted.current = false;
   }, []);
 
   const onPan = useCallback(
     (_: PointerEvent, info: PanInfo) => {
       const rawY = info.offset.y;
       const rawX = info.offset.x;
-
-      // Apply rubber banding beyond dismiss distance
-      const dampedY = dampen(rawY, DISTANCE_DISMISS);
-      const dampedX = dampen(rawX, DISTANCE_DISMISS);
-
-      dragY.jump(dampedY);
-      dragX.jump(dampedX);
-
       const dist = Math.sqrt(rawX * rawX + rawY * rawY);
+
+      // DD: gesture conflicts — don't start drag until threshold exceeded
+      if (!dragStarted.current) {
+        if (dist < DRAG_THRESHOLD) return;
+        dragStarted.current = true;
+        gesture.start();
+      }
+
+      dragY.jump(dampen(rawY, DISTANCE_DISMISS));
+      dragX.jump(dampen(rawX, DISTANCE_DISMISS));
       dragDistance.jump(dist);
     },
     [dragY, dragX, dragDistance]
@@ -161,7 +172,12 @@ export function ImageLightbox() {
 
   const onPanEnd = useCallback(
     (_: PointerEvent, info: PanInfo) => {
-      isDragging.current = false;
+      if (!dragStarted.current) {
+        // No significant drag occurred — treat as click to close
+        return;
+      }
+
+      dragStarted.current = false;
       gesture.end();
 
       const speed = Math.sqrt(
@@ -171,8 +187,8 @@ export function ImageLightbox() {
         info.offset.x * info.offset.x + info.offset.y * info.offset.y
       );
 
+      // DD: applying velocity — projected position determines dismiss
       if (speed > VELOCITY_DISMISS || dist > DISTANCE_DISMISS) {
-        // Dismiss
         closeLightbox();
       } else {
         // Snap back with spring
@@ -184,12 +200,14 @@ export function ImageLightbox() {
     [closeLightbox, dragY, dragX, dragDistance]
   );
 
-  // Click on overlay to close (but not during drag)
+  // Click on overlay to close (DD: prefer click over mousedown for interruptibility)
   const onOverlayClick = useCallback(
     (e: React.MouseEvent) => {
-      if (isDragging.current) return;
-      // Only close if clicking the overlay, not the image
-      if (e.target === e.currentTarget || (e.target as HTMLElement).id === "lightbox-overlay-bg") {
+      if (dragStarted.current) return;
+      if (
+        e.target === e.currentTarget ||
+        (e.target as HTMLElement).id === "lightbox-overlay-bg"
+      ) {
         closeLightbox();
       }
     },
@@ -203,27 +221,22 @@ export function ImageLightbox() {
       {isOpen && activeImage && (
         <motion.div
           id="lightbox-overlay"
-          ref={containerRef}
           className="fixed inset-0 z-[9999] flex items-center justify-center"
           style={{ touchAction: "none" }}
           onClick={onOverlayClick}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={CLOSE_SPRING}
+          transition={closeTransition}
         >
-          {/* Background overlay */}
+          {/* Background overlay — opacity driven by drag distance (interpolation) */}
           <motion.div
             id="lightbox-overlay-bg"
             className="absolute inset-0 bg-black/80"
             style={{ opacity: overlayOpacity }}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={OPEN_SPRING}
           />
 
-          {/* Image */}
+          {/* Image — no layoutId since source imgs are plain HTML */}
           <motion.img
             src={activeImage.src}
             alt={activeImage.alt}
@@ -232,29 +245,19 @@ export function ImageLightbox() {
               x: dragX,
               y: dragY,
               scale: imageScale,
-              cursor: isOpen ? "grab" : "default",
+              cursor: "grab",
               touchAction: "none",
             }}
-            layoutId={`lightbox-${activeImage.src}`}
-            initial={{
-              opacity: 0,
-              scale: 0.7,
-            }}
-            animate={{
-              opacity: 1,
-              scale: 1,
-            }}
-            exit={{
-              opacity: 0,
-              scale: 0.7,
-            }}
-            transition={isOpen ? OPEN_SPRING : CLOSE_SPRING}
+            initial={{ opacity: 0, scale: 0.7 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.85 }}
+            transition={isOpen ? openTransition : closeTransition}
             onPanStart={onPanStart}
             onPan={onPan}
             onPanEnd={onPanEnd}
             draggable={false}
             onPointerDown={(e: React.PointerEvent) => {
-              // Pointer capture (DD: contained-gestures)
+              // DD: contained-gestures — pointer capture
               (e.target as HTMLElement).setPointerCapture(e.pointerId);
             }}
           />

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,0 +1,265 @@
+import {
+  AnimatePresence,
+  motion,
+  useMotionValue,
+  useTransform,
+  type PanInfo,
+} from "framer-motion";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+// --- Spring configs (DD: simulating-physics) ---
+const OPEN_SPRING = { type: "spring" as const, stiffness: 300, damping: 30 };
+const CLOSE_SPRING = { type: "spring" as const, stiffness: 500, damping: 35 };
+
+// --- Thresholds ---
+const VELOCITY_DISMISS = 500; // px/s — fast drag dismisses immediately
+const DISTANCE_DISMISS = 150; // px — slow drag past this distance dismisses
+
+// --- Rubber banding (DD: rubber-banding dampen function) ---
+function dampen(val: number, max: number): number {
+  const abs = Math.abs(val);
+  if (abs > max) {
+    const extra = abs - max;
+    const dampenedExtra = Math.sqrt(extra) * 3;
+    return Math.sign(val) * (max + dampenedExtra);
+  }
+  return val;
+}
+
+// --- Contained gesture helpers (DD: contained-gestures) ---
+const gesture = {
+  start: () => {
+    document.body.style.cursor = "grabbing";
+    document.body.style.userSelect = "none";
+    // Disable pointer events on everything else during drag
+    const style = document.createElement("style");
+    style.id = "lightbox-gesture";
+    style.textContent = "body > *:not(#lightbox-overlay) { pointer-events: none !important; }";
+    document.head.appendChild(style);
+  },
+  end: () => {
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+    document.getElementById("lightbox-gesture")?.remove();
+  },
+};
+
+interface LightboxImage {
+  src: string;
+  alt: string;
+  rect: DOMRect;
+}
+
+export function ImageLightbox() {
+  const [activeImage, setActiveImage] = useState<LightboxImage | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Drag motion values
+  const dragY = useMotionValue(0);
+  const dragX = useMotionValue(0);
+
+  // Opacity linked to drag distance
+  const dragDistance = useMotionValue(0);
+  const overlayOpacity = useTransform(dragDistance, [0, DISTANCE_DISMISS * 2], [1, 0.2]);
+
+  // Scale linked to drag distance for tactile feedback
+  const imageScale = useTransform(dragDistance, [0, DISTANCE_DISMISS * 2], [1, 0.85]);
+
+  const isDragging = useRef(false);
+
+  // Open lightbox
+  const openLightbox = useCallback((img: HTMLImageElement) => {
+    const rect = img.getBoundingClientRect();
+    setActiveImage({
+      src: img.src,
+      alt: img.alt || "",
+      rect,
+    });
+    setIsOpen(true);
+    document.body.style.overflow = "hidden";
+  }, []);
+
+  // Close lightbox
+  const closeLightbox = useCallback(() => {
+    setIsOpen(false);
+    document.body.style.overflow = "";
+    gesture.end();
+    // Clean up after exit animation
+    setTimeout(() => {
+      setActiveImage(null);
+      dragY.jump(0);
+      dragX.jump(0);
+      dragDistance.jump(0);
+    }, 400);
+  }, [dragY, dragX, dragDistance]);
+
+  // Esc key handler
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && isOpen) {
+        closeLightbox();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, closeLightbox]);
+
+  // Attach click handlers to blog post images
+  useEffect(() => {
+    const postContent = document.getElementById("post-content");
+    if (!postContent) return;
+
+    const imgs = postContent.querySelectorAll("img");
+
+    function handleClick(e: Event) {
+      const img = e.currentTarget as HTMLImageElement;
+      // Don't open for tiny images (icons, etc.)
+      if (img.naturalWidth < 100 || img.naturalHeight < 100) return;
+      openLightbox(img);
+    }
+
+    imgs.forEach((img) => {
+      img.addEventListener("click", handleClick);
+      img.style.cursor = "zoom-in";
+      // Fitts' Law: expand hit area with padding (DD: ergonomic-interactions)
+      img.style.padding = "8px";
+      img.style.margin = "-8px";
+      img.style.boxSizing = "content-box";
+    });
+
+    return () => {
+      imgs.forEach((img) => {
+        img.removeEventListener("click", handleClick);
+      });
+    };
+  }, [openLightbox]);
+
+  // --- Drag handlers ---
+  const onPanStart = useCallback(() => {
+    isDragging.current = true;
+    gesture.start();
+  }, []);
+
+  const onPan = useCallback(
+    (_: PointerEvent, info: PanInfo) => {
+      const rawY = info.offset.y;
+      const rawX = info.offset.x;
+
+      // Apply rubber banding beyond dismiss distance
+      const dampedY = dampen(rawY, DISTANCE_DISMISS);
+      const dampedX = dampen(rawX, DISTANCE_DISMISS);
+
+      dragY.jump(dampedY);
+      dragX.jump(dampedX);
+
+      const dist = Math.sqrt(rawX * rawX + rawY * rawY);
+      dragDistance.jump(dist);
+    },
+    [dragY, dragX, dragDistance]
+  );
+
+  const onPanEnd = useCallback(
+    (_: PointerEvent, info: PanInfo) => {
+      isDragging.current = false;
+      gesture.end();
+
+      const speed = Math.sqrt(
+        info.velocity.x * info.velocity.x + info.velocity.y * info.velocity.y
+      );
+      const dist = Math.sqrt(
+        info.offset.x * info.offset.x + info.offset.y * info.offset.y
+      );
+
+      if (speed > VELOCITY_DISMISS || dist > DISTANCE_DISMISS) {
+        // Dismiss
+        closeLightbox();
+      } else {
+        // Snap back with spring
+        dragY.set(0);
+        dragX.set(0);
+        dragDistance.set(0);
+      }
+    },
+    [closeLightbox, dragY, dragX, dragDistance]
+  );
+
+  // Click on overlay to close (but not during drag)
+  const onOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (isDragging.current) return;
+      // Only close if clicking the overlay, not the image
+      if (e.target === e.currentTarget || (e.target as HTMLElement).id === "lightbox-overlay-bg") {
+        closeLightbox();
+      }
+    },
+    [closeLightbox]
+  );
+
+  if (!activeImage && !isOpen) return null;
+
+  return (
+    <AnimatePresence>
+      {isOpen && activeImage && (
+        <motion.div
+          id="lightbox-overlay"
+          ref={containerRef}
+          className="fixed inset-0 z-[9999] flex items-center justify-center"
+          style={{ touchAction: "none" }}
+          onClick={onOverlayClick}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={CLOSE_SPRING}
+        >
+          {/* Background overlay */}
+          <motion.div
+            id="lightbox-overlay-bg"
+            className="absolute inset-0 bg-black/80"
+            style={{ opacity: overlayOpacity }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={OPEN_SPRING}
+          />
+
+          {/* Image */}
+          <motion.img
+            src={activeImage.src}
+            alt={activeImage.alt}
+            className="relative max-h-[90vh] max-w-[90vw] object-contain rounded-lg select-none"
+            style={{
+              x: dragX,
+              y: dragY,
+              scale: imageScale,
+              cursor: isOpen ? "grab" : "default",
+              touchAction: "none",
+            }}
+            layoutId={`lightbox-${activeImage.src}`}
+            initial={{
+              opacity: 0,
+              scale: 0.7,
+            }}
+            animate={{
+              opacity: 1,
+              scale: 1,
+            }}
+            exit={{
+              opacity: 0,
+              scale: 0.7,
+            }}
+            transition={isOpen ? OPEN_SPRING : CLOSE_SPRING}
+            onPanStart={onPanStart}
+            onPan={onPan}
+            onPanEnd={onPanEnd}
+            draggable={false}
+            onPointerDown={(e: React.PointerEvent) => {
+              // Pointer capture (DD: contained-gestures)
+              (e.target as HTMLElement).setPointerCapture(e.pointerId);
+            }}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/blog/AnimatedPostList.tsx
+++ b/src/components/blog/AnimatedPostList.tsx
@@ -1,0 +1,165 @@
+import { motion, useReducedMotion } from "framer-motion";
+import { useEffect, useState } from "react";
+
+interface PostData {
+  title: string;
+  description: string;
+  date: string;
+  draft?: boolean;
+  categories?: string[];
+}
+
+interface PostEntry {
+  id: string;
+  collection: string;
+  data: PostData;
+}
+
+interface YearGroup {
+  year: string;
+  posts: PostEntry[];
+}
+
+interface Props {
+  years: YearGroup[];
+  isDev: boolean;
+}
+
+const itemVariants = {
+  hidden: {
+    opacity: 0,
+    y: 12,
+  },
+  visible: (index: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.3,
+      ease: [0.165, 0.84, 0.44, 1],
+      delay: index * 0.05,
+    },
+  }),
+};
+
+function PostCard({ post, isDev }: { post: PostEntry; isDev: boolean }) {
+  return (
+    <a
+      href={`/${post.collection}/${post.id}`}
+      className="relative group flex flex-nowrap py-3 pr-10 rounded-lg hover:text-black transition-colors duration-300 ease-in-out antialiased"
+    >
+      <div className="flex flex-col flex-1 truncate">
+        <div className="font-bold text-zinc-600 group-hover:text-black transition-colors duration-300 ease-in-out whitespace-normal break-all line-clamp-2">
+          {post.data.title}
+          {isDev && post.data.draft && (
+            <span className="inline-flex items-center ml-2 px-1.5 py-0.5 text-[10px] font-medium leading-none text-orange-600 bg-orange-100 rounded align-middle">
+              DRAFT
+            </span>
+          )}
+        </div>
+        <div className="text-sm line-clamp-2 whitespace-normal break-all text-semibold">
+          {post.data.description}
+        </div>
+      </div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        className="absolute top-1/2 right-2 -translate-y-1/2 size-5 stroke-2 fill-none stroke-current"
+      >
+        <line
+          x1="5"
+          y1="12"
+          x2="19"
+          y2="12"
+          className="translate-x-3 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out"
+        />
+        <polyline
+          points="12 5 19 12 12 19"
+          className="-translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out"
+        />
+      </svg>
+    </a>
+  );
+}
+
+export default function AnimatedPostList({ years, isDev }: Props) {
+  const prefersReducedMotion = useReducedMotion();
+  const [shouldAnimate, setShouldAnimate] = useState(false);
+
+  useEffect(() => {
+    // After hydration, trigger the stagger animation.
+    // client:visible ensures this only runs when the component is in the viewport.
+    if (prefersReducedMotion) {
+      setShouldAnimate(true);
+      return;
+    }
+
+    // Small delay to ensure CSS initial state (opacity: 0) is applied
+    // before framer-motion takes over, preventing a flash.
+    const raf = requestAnimationFrame(() => {
+      setShouldAnimate(true);
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [prefersReducedMotion]);
+
+  let globalIndex = 0;
+
+  return (
+    <div className="space-y-4">
+      {years.map(({ year, posts }) => {
+        const sectionStartIndex = globalIndex;
+        globalIndex += posts.length;
+
+        return (
+          <section
+            key={year}
+            className="space-y-4"
+            data-year={year}
+          >
+            <motion.div
+              className="font-semibold text-black"
+              initial={{ opacity: 0, y: 8 }}
+              animate={
+                prefersReducedMotion || shouldAnimate
+                  ? { opacity: 1, y: 0 }
+                  : { opacity: 0, y: 8 }
+              }
+              transition={{
+                duration: 0.3,
+                ease: [0.165, 0.84, 0.44, 1],
+                delay: sectionStartIndex * 0.05,
+              }}
+            >
+              {year}
+            </motion.div>
+            <div>
+              <ul className="flex flex-col gap-4">
+                {posts.map((post, i) => {
+                  const itemIndex = sectionStartIndex + i;
+                  return (
+                    <motion.li
+                      key={post.id}
+                      data-categories={JSON.stringify(
+                        post.data.categories || []
+                      )}
+                      custom={itemIndex}
+                      initial="hidden"
+                      animate={
+                        prefersReducedMotion || shouldAnimate
+                          ? "visible"
+                          : "hidden"
+                      }
+                      variants={itemVariants}
+                    >
+                      <PostCard post={post} isDev={isDev} />
+                    </motion.li>
+                  );
+                })}
+              </ul>
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/blog/ArrowCard.astro
+++ b/src/components/blog/ArrowCard.astro
@@ -1,51 +1,20 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import ArrowCardInteractive from "./ArrowCardInteractive";
 
 type Props = {
   entry: CollectionEntry<"blog">;
 };
 
 const { entry } = Astro.props;
+const isDev = import.meta.env.DEV;
 ---
 
-<a
+<ArrowCardInteractive
+  client:visible
   href={`/${entry.collection}/${entry.id}`}
-  class="relative group flex flex-nowrap py-3 pr-10 rounded-lg hover:text-black transition-colors duration-300 ease-in-out antialiased"
->
-  <div class="flex flex-col flex-1 truncate">
-    <div
-      class="font-bold text-zinc-600 group-hover:text-black transition-colors duration-300 ease-in-out
-        whitespace-normal break-all line-clamp-2"
-    >
-      {entry.data.title}
-      {import.meta.env.DEV && entry.data.draft && (
-        <span class="inline-flex items-center ml-2 px-1.5 py-0.5 text-[10px] font-medium leading-none text-orange-600 bg-orange-100 rounded align-middle">
-          DRAFT
-        </span>
-      )}
-    </div>
-    <div class="text-sm line-clamp-2 whitespace-normal break-all text-semibold">
-      {entry.data.description}
-    </div>
-    <!-- <div class="text-xs text-gray-500 dark:text-gray-400">
-      {entry.data.date}
-    </div> -->
-  </div>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    class="absolute top-1/2 right-2 -translate-y-1/2 size-5 stroke-2 fill-none stroke-current"
-  >
-    <line
-      x1="5"
-      y1="12"
-      x2="19"
-      y2="12"
-      class="translate-x-3 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out"
-    ></line>
-    <polyline
-      points="12 5 19 12 12 19"
-      class="-translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out"
-    ></polyline>
-  </svg>
-</a>
+  title={entry.data.title}
+  description={entry.data.description}
+  draft={entry.data.draft}
+  isDev={isDev}
+/>

--- a/src/components/blog/ArrowCardInteractive.tsx
+++ b/src/components/blog/ArrowCardInteractive.tsx
@@ -1,0 +1,113 @@
+import { motion, useSpring, useTransform, useMotionValue } from "framer-motion";
+
+type Props = {
+  href: string;
+  title: string;
+  description?: string;
+  draft?: boolean;
+  isDev?: boolean;
+};
+
+// Spring configs following DD principles:
+// "higher stiffness = faster movement; lower damping = more bounce"
+// For hover, we want responsive but NOT bouncy (no momentum in hover)
+const CARD_SPRING = { stiffness: 400, damping: 25 };
+// Arrow gets slightly lower damping for follow-through effect
+const ARROW_SPRING = { stiffness: 400, damping: 20 };
+
+export default function ArrowCardInteractive({
+  href,
+  title,
+  description,
+  draft,
+  isDev,
+}: Props) {
+  const isHovered = useMotionValue(0);
+
+  // Card transforms — subtle, not exaggerated
+  const cardY = useSpring(0, CARD_SPRING);
+  const cardScale = useSpring(1, CARD_SPRING);
+
+  // Arrow transforms — follow-through with lower damping
+  const arrowX = useSpring(0, ARROW_SPRING);
+  // Arrow line scale for the reveal effect
+  const arrowLineScaleX = useSpring(0, ARROW_SPRING);
+  // Arrow line translate — starts offset, moves to 0
+  const arrowLineX = useSpring(12, ARROW_SPRING);
+
+  // Text color interpolation
+  const titleColor = useTransform(isHovered, [0, 1], ["#52525b", "#000000"]);
+  const titleColorSpring = useSpring(titleColor, CARD_SPRING);
+
+  const handleHoverStart = () => {
+    isHovered.set(1);
+    cardY.set(-2);
+    cardScale.set(1.015);
+    arrowX.set(0);
+    arrowLineScaleX.set(1);
+    arrowLineX.set(0);
+  };
+
+  const handleHoverEnd = () => {
+    isHovered.set(0);
+    cardY.set(0);
+    cardScale.set(1);
+    arrowX.set(-4);
+    arrowLineScaleX.set(0);
+    arrowLineX.set(12);
+  };
+
+  return (
+    <motion.a
+      href={href}
+      className="relative group flex flex-nowrap py-3 pr-10 rounded-lg antialiased"
+      style={{
+        y: cardY,
+        scale: cardScale,
+      }}
+      onHoverStart={handleHoverStart}
+      onHoverEnd={handleHoverEnd}
+      onFocus={handleHoverStart}
+      onBlur={handleHoverEnd}
+    >
+      <div className="flex flex-col flex-1 truncate">
+        <motion.div
+          className="font-bold whitespace-normal break-all line-clamp-2"
+          style={{ color: titleColorSpring }}
+        >
+          {title}
+          {isDev && draft && (
+            <span className="inline-flex items-center ml-2 px-1.5 py-0.5 text-[10px] font-medium leading-none text-orange-600 bg-orange-100 rounded align-middle">
+              DRAFT
+            </span>
+          )}
+        </motion.div>
+        <div className="text-sm line-clamp-2 whitespace-normal break-all text-semibold">
+          {description}
+        </div>
+      </div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        className="absolute top-1/2 right-2 -translate-y-1/2 size-5 stroke-2 fill-none stroke-current"
+      >
+        <motion.line
+          x1="5"
+          y1="12"
+          x2="19"
+          y2="12"
+          style={{
+            scaleX: arrowLineScaleX,
+            x: arrowLineX,
+          }}
+        />
+        <motion.polyline
+          points="12 5 19 12 12 19"
+          style={{
+            x: arrowX,
+          }}
+        />
+      </svg>
+    </motion.a>
+  );
+}

--- a/src/components/blog/TOC.astro
+++ b/src/components/blog/TOC.astro
@@ -1,5 +1,6 @@
 ---
 import type { MarkdownHeading } from 'astro'
+import TOCEnhanced from './TOCEnhanced.tsx'
 
 interface Props {
   headings: MarkdownHeading[]
@@ -15,8 +16,8 @@ const filteredHeadings = headings.filter(heading =>
   <!-- TOC Container -->
   <div
     id="toc-container"
-    class="mb-6 rounded-lg border border-zinc-200 bg-zinc-50/50 p-1 
-           lg:fixed lg:left-[calc(50%+28rem)] lg:top-44 lg:w-68 
+    class="mb-6 rounded-lg border border-zinc-200 bg-zinc-50/50 p-1
+           lg:fixed lg:left-[calc(50%+28rem)] lg:top-44 lg:w-68
            lg:border-none lg:bg-transparent lg:p-0"
   >
     <!-- Hidden Checkbox for mobile toggle -->
@@ -25,7 +26,7 @@ const filteredHeadings = headings.filter(heading =>
       id="toc-toggle"
       class="hidden"
     />
-    
+
     <!-- TOC Header - Mobile Only -->
     <div class="relative h-12 w-full lg:hidden">
       <label
@@ -37,34 +38,25 @@ const filteredHeadings = headings.filter(heading =>
         </span>
       </label>
     </div>
-    
-    <!-- Expandable Content Wrapper -->
-    <div id="toc-accordion-wrapper" class="grid grid-rows-[0fr] transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr]">
+
+    <!-- Expandable Content Wrapper (Mobile accordion) -->
+    <div id="toc-accordion-wrapper" class="grid grid-rows-[0fr] transition-[grid-template-rows] duration-300 ease-in-out lg:hidden">
       <nav
         id="toc-accordion-content"
-        class="overflow-hidden px-4 lg:max-h-[calc(100vh-12rem)] lg:overflow-y-auto lg:px-0 relative"
+        class="overflow-hidden px-4"
         aria-label="Table of Contents"
       >
-        <!-- Progress Line (Desktop Only) -->
-        <div class="hidden lg:block absolute left-0 top-0 bottom-0 w-8">
-          <svg
-            id="toc-lines-svg"
-            class="absolute inset-0 w-full h-full"
-            aria-hidden="true"
-          ></svg>
-        </div>
-
-        <!-- TOC List -->
-        <ul id="toc-links-list" class="mb-2.5 mt-1 list-none space-y-1 pl-0 lg:pl-8 lg:mb-1 lg:space-y-1.5 relative">
+        <!-- TOC List (Mobile only) -->
+        <ul id="toc-links-list" class="mb-2.5 mt-1 list-none space-y-1 pl-0">
           {filteredHeadings.map((heading, index) => (
             <li
               data-depth={heading.depth}
               data-index={index}
               class:list={{
                 'toc-item relative': true,
-                'ml-0 lg:ml-0': heading.depth === 2,
-                'ml-4 lg:ml-4': heading.depth === 3,
-                'ml-8 lg:ml-8': heading.depth === 4,
+                'ml-0': heading.depth === 2,
+                'ml-4': heading.depth === 3,
+                'ml-8': heading.depth === 4,
               }}
             >
               <a
@@ -74,7 +66,6 @@ const filteredHeadings = headings.filter(heading =>
                   { 'toc-links-h2': heading.depth === 2 },
                   { 'toc-links-h3': heading.depth === 3 },
                   { 'toc-links-h4': heading.depth === 4 },
-                  'lg:text-xs lg:text-zinc-400',
                 ]}
                 title={heading.text}
               >
@@ -84,6 +75,11 @@ const filteredHeadings = headings.filter(heading =>
           ))}
         </ul>
       </nav>
+    </div>
+
+    <!-- Desktop Enhanced TOC (React island with proximity effects) -->
+    <div class="hidden lg:block lg:max-h-[calc(100vh-12rem)] lg:overflow-y-auto" id="toc-enhanced-wrapper">
+      <TOCEnhanced headings={headings} client:visible />
     </div>
   </div>
 )}
@@ -99,177 +95,24 @@ const filteredHeadings = headings.filter(heading =>
     grid-template-rows: 1fr;
   }
 
-  /* Desktop: always open, hide checkbox behavior */
-  @media (min-width: 1024px) {
-    #toc-toggle:checked ~ #toc-accordion-wrapper {
-      grid-template-rows: 1fr;
-    }
-  }
-
-  /* Scrollbar styling */
-  #toc-accordion-content {
+  /* Scrollbar styling for enhanced wrapper */
+  #toc-enhanced-wrapper {
     scrollbar-width: thin;
     scrollbar-color: rgb(161 161 170 / 0.3) transparent;
   }
 
-  #toc-accordion-content::-webkit-scrollbar {
+  #toc-enhanced-wrapper::-webkit-scrollbar {
     width: 4px;
   }
 
-  #toc-accordion-content::-webkit-scrollbar-track {
+  #toc-enhanced-wrapper::-webkit-scrollbar-track {
     background: transparent;
   }
 
-  #toc-accordion-content::-webkit-scrollbar-thumb {
+  #toc-enhanced-wrapper::-webkit-scrollbar-thumb {
     background-color: rgb(161 161 170 / 0.3);
     border-radius: 2px;
   }
 
-  /* Animation for TOC items */
-  @media (min-width: 1024px) {
-    #toc-links-list > * {
-      opacity: 0;
-      animation: fadeInUp 0.5s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
-    }
-
-    #toc-links-list > *:nth-child(1) { animation-delay: 0.175s; }
-    #toc-links-list > *:nth-child(2) { animation-delay: 0.2s; }
-    #toc-links-list > *:nth-child(3) { animation-delay: 0.225s; }
-    #toc-links-list > *:nth-child(4) { animation-delay: 0.25s; }
-    #toc-links-list > *:nth-child(5) { animation-delay: 0.275s; }
-    #toc-links-list > *:nth-child(6) { animation-delay: 0.3s; }
-    #toc-links-list > *:nth-child(7) { animation-delay: 0.325s; }
-    #toc-links-list > *:nth-child(8) { animation-delay: 0.35s; }
-    #toc-links-list > *:nth-child(9) { animation-delay: 0.375s; }
-    #toc-links-list > *:nth-child(10) { animation-delay: 0.4s; }
-    #toc-links-list > *:nth-child(n+11) { animation-delay: 0.425s; }
-
-    /* CSS Scroll-driven TOC highlight using modern CSS */
-    #toc-links-list {
-      scroll-target-group: auto;
-    }
-
-    /* Active link styles via :target-current */
-    .toc-link:target-current {
-      color: rgb(39 39 42);
-      font-weight: 500;
-      anchor-name: --active-toc;
-    }
-
-    /* CSS Anchor-positioned indicator (the moving dot) */
-    #toc-accordion-content::after {
-      content: '';
-      position: absolute;
-      position-anchor: --active-toc;
-      width: 8px;
-      height: 8px;
-      background: rgb(39 39 42);
-      border-radius: 50%;
-      top: anchor(center);
-      left: anchor(left);
-      transform: translate3d(-28px, -50%, 0);
-      transition: top 0.3s ease-out, left 0.3s ease-out, transform 0.3s ease-out;
-      z-index: 1;
-      will-change: transform, top, left;
-    }
-
-    /* Adjust indicator position per depth */
-    #toc-accordion-content:has(.toc-item[data-depth="3"] .toc-link:target-current)::after {
-      transform: translate3d(-36px, -50%, 0);
-    }
-
-    #toc-accordion-content:has(.toc-item[data-depth="4"] .toc-link:target-current)::after {
-      transform: translate3d(-44px, -50%, 0);
-    }
-
-    /* SVG line animation on load */
-    .toc-line-path {
-      animation: drawPath 0.8s ease-out forwards;
-    }
-
-    @keyframes drawPath {
-      from {
-        stroke-dasharray: 200;
-        stroke-dashoffset: 200;
-      }
-      to {
-        stroke-dasharray: 200;
-        stroke-dashoffset: 0;
-      }
-    }
-
-    /* Hover effect on container */
-    #toc-container:hover .toc-link {
-      color: rgb(113 113 122);
-    }
-
-    #toc-container:hover .toc-link:hover {
-      color: rgb(0 0 0);
-    }
-
-    #toc-container:hover .toc-link:target-current {
-      color: rgb(0 0 0);
-    }
-  }
+  /* Desktop entry animation is handled in global.css */
 </style>
-
-<!-- TOC Script -->
-<script>
-function drawTOCLines() {
-  const svg = document.getElementById('toc-lines-svg') as SVGElement
-  if (!svg) return
-
-  const tocItems = document.querySelectorAll('.toc-item')
-  if (tocItems.length === 0) return
-
-  svg.innerHTML = ''
-
-  const xPositions = { 2: 8, 3: 16, 4: 24 }
-
-  let prevDepth = 2
-  let prevY = 0
-
-  tocItems.forEach((item, index) => {
-    const depth = parseInt((item as HTMLElement).dataset.depth || '2')
-    const rect = item.getBoundingClientRect()
-    const containerRect = svg.getBoundingClientRect()
-    const y = rect.top - containerRect.top + rect.height / 2
-
-    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
-    const currentX = xPositions[depth as keyof typeof xPositions] || 8
-    const prevX = xPositions[prevDepth as keyof typeof xPositions] || 8
-
-    if (index === 0) {
-      path.setAttribute('d', `M ${currentX} 0 L ${currentX} ${y}`)
-    } else {
-      if (depth !== prevDepth) {
-        const midY = prevY + 8
-        path.setAttribute('d', `M ${prevX} ${prevY} L ${prevX} ${midY} L ${currentX} ${y}`)
-      } else {
-        path.setAttribute('d', `M ${currentX} ${prevY} L ${currentX} ${y}`)
-      }
-    }
-
-    path.setAttribute('stroke', 'rgb(228 228 231)')
-    path.setAttribute('stroke-width', '1')
-    path.setAttribute('fill', 'none')
-    path.setAttribute('class', 'toc-line-path')
-
-    svg.appendChild(path)
-
-    prevDepth = depth
-    prevY = y
-  })
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-  if (window.innerWidth >= 1024) {
-    drawTOCLines()
-  }
-})
-window.addEventListener('resize', () => {
-  if (window.innerWidth >= 1024) {
-    drawTOCLines()
-  }
-})
-</script>

--- a/src/components/blog/TOCEnhanced.tsx
+++ b/src/components/blog/TOCEnhanced.tsx
@@ -1,0 +1,250 @@
+import {
+  motion,
+  useSpring,
+  useMotionValue,
+  useMotionValueEvent,
+  type MotionValue,
+} from "framer-motion";
+import { useEffect, useRef, useState, useCallback } from "react";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface TOCEnhancedProps {
+  headings: Heading[];
+}
+
+// ─── Proximity constants (adapted from DD line-minimap) ──────────────────────
+
+/** Max index distance before the effect falls off completely */
+const PROXIMITY_RANGE = 3;
+
+/** Spring config for text property transitions */
+const TEXT_SPRING = { stiffness: 400, damping: 35, mass: 0.8 };
+
+/** Spring config for the indicator bar position */
+const INDICATOR_SPRING = { stiffness: 300, damping: 30, mass: 0.6 };
+
+// ─── Proximity calculation ───────────────────────────────────────────────────
+
+/**
+ * Compute a 0..1 proximity factor from the active index.
+ * 0 = far away (beyond PROXIMITY_RANGE), 1 = active item itself.
+ *
+ * Inspired by DD's `transformScale`:
+ *   normalizedDistance = 1 - |distance| / DISTANCE_LIMIT
+ *   factor = normalizedDistance^2
+ */
+function proximityFactor(itemIndex: number, activeIndex: number): number {
+  const distance = Math.abs(itemIndex - activeIndex);
+  if (distance > PROXIMITY_RANGE) return 0;
+  const normalized = 1 - distance / PROXIMITY_RANGE;
+  return normalized * normalized; // quadratic falloff like DD
+}
+
+// ─── Per-item animated component ─────────────────────────────────────────────
+
+function TOCItem({
+  heading,
+  index,
+  activeIndex,
+}: {
+  heading: Heading;
+  index: number;
+  activeIndex: MotionValue<number>;
+}) {
+  const opacity = useSpring(0.4, TEXT_SPRING);
+  const fontWeight = useSpring(400, TEXT_SPRING);
+  const scale = useSpring(1, TEXT_SPRING);
+
+  useMotionValueEvent(activeIndex, "change", (latest) => {
+    const factor = proximityFactor(index, latest);
+
+    // Active item (factor ≈ 1): full opacity, bold, slight scale-up
+    // Adjacent (factor ≈ 0.44): medium opacity/weight
+    // Far (factor = 0): dim, normal weight
+    opacity.set(0.4 + factor * 0.6);           // 0.4 → 1.0
+    fontWeight.set(400 + factor * 200);         // 400 → 600
+    scale.set(1 + factor * 0.02);               // 1 → 1.02
+  });
+
+  const depthMargin = heading.depth === 3 ? 16 : heading.depth === 4 ? 32 : 0;
+
+  return (
+    <motion.li
+      className="toc-enhanced-item relative list-none"
+      style={{
+        marginLeft: depthMargin,
+      }}
+    >
+      <motion.a
+        href={`#${heading.slug}`}
+        className="toc-enhanced-link block text-xs text-zinc-900 no-underline truncate leading-relaxed"
+        style={{
+          opacity,
+          fontWeight,
+          scale,
+          transformOrigin: "left center",
+        }}
+        title={heading.text}
+      >
+        {heading.text}
+      </motion.a>
+    </motion.li>
+  );
+}
+
+// ─── Active section indicator bar ────────────────────────────────────────────
+
+function ActiveIndicator({
+  y,
+  height,
+}: {
+  y: MotionValue<number>;
+  height: MotionValue<number>;
+}) {
+  return (
+    <motion.div
+      className="absolute left-0 w-[2px] rounded-full bg-zinc-900"
+      style={{
+        y,
+        height,
+        transformOrigin: "top left",
+      }}
+    />
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────────────────────
+
+export default function TOCEnhanced({ headings }: TOCEnhancedProps) {
+  const filtered = headings.filter((h) => h.depth >= 2 && h.depth <= 4);
+  const listRef = useRef<HTMLUListElement>(null);
+  const activeIndex = useMotionValue(-1);
+  const indicatorY = useSpring(0, INDICATOR_SPRING);
+  const indicatorHeight = useSpring(0, INDICATOR_SPRING);
+  const [mounted, setMounted] = useState(false);
+
+  // ── Observe headings in the document ───────────────────────────────────────
+
+  const updateIndicator = useCallback(
+    (index: number) => {
+      if (!listRef.current || index < 0) return;
+      const items = listRef.current.querySelectorAll(".toc-enhanced-item");
+      const item = items[index] as HTMLElement | undefined;
+      if (!item) return;
+
+      const listRect = listRef.current.getBoundingClientRect();
+      const itemRect = item.getBoundingClientRect();
+
+      indicatorY.set(itemRect.top - listRect.top);
+      indicatorHeight.set(itemRect.height);
+    },
+    [indicatorY, indicatorHeight],
+  );
+
+  useEffect(() => {
+    setMounted(true);
+
+    const headingEls = filtered
+      .map((h) => document.getElementById(h.slug))
+      .filter(Boolean) as HTMLElement[];
+
+    if (headingEls.length === 0) return;
+
+    // Track which headings are currently visible
+    const visibleSet = new Set<string>();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            visibleSet.add(entry.target.id);
+          } else {
+            visibleSet.delete(entry.target.id);
+          }
+        });
+
+        // Find the topmost visible heading
+        let topIndex = -1;
+        for (let i = 0; i < filtered.length; i++) {
+          if (visibleSet.has(filtered[i].slug)) {
+            topIndex = i;
+            break;
+          }
+        }
+
+        // If nothing visible, find the last heading that's above the viewport
+        if (topIndex === -1) {
+          for (let i = filtered.length - 1; i >= 0; i--) {
+            const el = document.getElementById(filtered[i].slug);
+            if (el) {
+              const rect = el.getBoundingClientRect();
+              if (rect.top < 100) {
+                topIndex = i;
+                break;
+              }
+            }
+          }
+        }
+
+        if (topIndex >= 0) {
+          activeIndex.set(topIndex);
+          updateIndicator(topIndex);
+        }
+      },
+      {
+        // Offset to detect headings near the top of the viewport
+        rootMargin: "-80px 0px -60% 0px",
+        threshold: 0,
+      },
+    );
+
+    headingEls.forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [filtered, activeIndex, updateIndicator]);
+
+  // Re-calculate indicator position on resize
+  useEffect(() => {
+    const handleResize = () => {
+      const current = Math.round(activeIndex.get());
+      if (current >= 0) updateIndicator(current);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [activeIndex, updateIndicator]);
+
+  if (filtered.length === 0) return null;
+
+  return (
+    <nav
+      className="relative"
+      aria-label="Table of Contents (enhanced)"
+      style={{ opacity: mounted ? 1 : 0, transition: "opacity 0.3s ease" }}
+    >
+      {/* Active indicator bar */}
+      <ActiveIndicator y={indicatorY} height={indicatorHeight} />
+
+      {/* TOC list */}
+      <ul
+        ref={listRef}
+        className="relative list-none space-y-1.5 pl-3 m-0"
+      >
+        {filtered.map((heading, index) => (
+          <TOCItem
+            key={heading.slug}
+            heading={heading}
+            index={index}
+            activeIndex={activeIndex}
+          />
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/embeds/AudioPlayer.astro
+++ b/src/components/embeds/AudioPlayer.astro
@@ -5,203 +5,353 @@ interface Props {
 }
 
 const { src, title } = Astro.props;
+const playerId = `ap-${Math.random().toString(36).slice(2, 8)}`;
 ---
 
 <div
-  class="audio-player w-full max-w-full bg-white rounded-lg shadow-md p-4 my-4"
+  class="audio-player group relative w-full max-w-full rounded-lg border border-zinc-200 bg-white my-4 select-none"
+  data-player-id={playerId}
+  data-src={src}
 >
-  {title && <div class="text-lg font-medium mb-2">{title}</div>}
-  <div class="player-container">
-    <div class="flex items-center mb-2">
-      <button
-        id="playPauseBtn"
-        class="w-12 h-12 flex items-center justify-center bg-indigo-600 hover:bg-indigo-700 rounded-full text-white mr-4"
+  <div class="flex items-center gap-3 px-4 py-3">
+    <!-- Play/Pause button (DD: ergonomic-interactions — generous hit area) -->
+    <button
+      data-role="play-pause"
+      class="ap-play-btn relative flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-full bg-zinc-900 text-white transition-transform duration-150 ease-out active:scale-90 hover:bg-black focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-400"
+      aria-label="Play"
+    >
+      <!-- Play icon -->
+      <svg data-role="play-icon" class="w-4 h-4 ml-0.5" viewBox="0 0 16 16" fill="currentColor">
+        <path d="M4.5 2.5v11l9-5.5z" />
+      </svg>
+      <!-- Pause icon -->
+      <svg data-role="pause-icon" class="w-4 h-4 hidden" viewBox="0 0 16 16" fill="currentColor">
+        <rect x="3.5" y="2" width="3.5" height="12" rx="0.75" />
+        <rect x="9" y="2" width="3.5" height="12" rx="0.75" />
+      </svg>
+    </button>
+
+    <!-- Track info + progress -->
+    <div class="flex-1 min-w-0">
+      {title && <div class="text-sm font-medium text-zinc-800 truncate mb-1.5">{title}</div>}
+
+      <!-- Progress bar (DD: ergonomic-interactions — expanded hit area with padding) -->
+      <div
+        data-role="seek-area"
+        class="ap-seek-area relative py-2 -my-2 cursor-pointer"
+        style="touch-action: none;"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="play-icon h-6 w-6"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z"
-            clip-rule="evenodd"></path>
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="pause-icon h-6 w-6 hidden"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z"
-            clip-rule="evenodd"></path>
-        </svg>
-      </button>
-      <div class="flex-grow">
-        <div class="relative">
+        <!-- Track background -->
+        <div class="relative h-1 bg-zinc-200 rounded-full overflow-hidden transition-[height] duration-150">
+          <!-- Filled progress -->
           <div
-            class="progress-container w-full h-2 bg-gray-200 rounded-full overflow-hidden"
-          >
-            <div id="progressBar" class="progress-bar h-full bg-indigo-500 w-0">
-            </div>
-          </div>
-          <input
-            type="range"
-            id="seekBar"
-            class="absolute top-0 w-full h-2 opacity-0 cursor-pointer"
-            min="0"
-            max="100"
-            value="0"
-          />
+            data-role="progress-fill"
+            class="absolute inset-y-0 left-0 bg-zinc-700 rounded-full"
+            style="width: 0%; will-change: width;"
+          ></div>
         </div>
+
+        <!-- Hover time preview (DD: responsive-interfaces — proportional feedback) -->
         <div
-          class="flex justify-between text-xs text-gray-500 mt-1"
+          data-role="time-preview"
+          class="absolute -top-7 px-1.5 py-0.5 text-[10px] font-mono text-zinc-500 bg-white border border-zinc-200 rounded opacity-0 pointer-events-none transition-opacity duration-100 shadow-sm"
+          style="transform: translateX(-50%);"
         >
-          <span id="currentTime">0:00</span>
-          <span id="totalTime">0:00</span>
+          0:00
         </div>
+
+        <!-- Seek thumb (DD: responsive-interfaces — real-time gesture feedback) -->
+        <div
+          data-role="seek-thumb"
+          class="absolute top-1/2 -translate-y-1/2 w-3 h-3 bg-zinc-900 rounded-full opacity-0 transition-opacity duration-100 pointer-events-none shadow-sm"
+          style="transform: translate(-50%, -50%); will-change: left;"
+        ></div>
+      </div>
+
+      <!-- Time display -->
+      <div class="flex justify-between mt-1">
+        <span data-role="current-time" class="text-[11px] font-mono text-zinc-400 tabular-nums">0:00</span>
+        <span data-role="total-time" class="text-[11px] font-mono text-zinc-400 tabular-nums">0:00</span>
       </div>
     </div>
-    <div class="flex items-center">
-      <button id="muteBtn" class="text-gray-600 mr-2">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="volume-icon h-5 w-5"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 01-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z"
-            clip-rule="evenodd"></path>
+
+    <!-- Volume control -->
+    <div class="ap-volume-group relative flex items-center gap-1.5 flex-shrink-0">
+      <button
+        data-role="mute"
+        class="w-7 h-7 flex items-center justify-center text-zinc-400 hover:text-zinc-700 rounded transition-colors duration-100 active:scale-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-400"
+        aria-label="Mute"
+      >
+        <!-- Volume icon -->
+        <svg data-role="volume-icon" class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M7.563 2.069A.75.75 0 0 1 8 2.75v10.5a.75.75 0 0 1-1.238.57L3.472 11H1.75A.75.75 0 0 1 1 10.25v-4.5A.75.75 0 0 1 1.75 5h1.722l3.29-2.82a.75.75 0 0 1 .801-.111ZM10.5 4.5a.5.5 0 0 1 .707 0 5.5 5.5 0 0 1 0 7.778.5.5 0 1 1-.707-.707 4.5 4.5 0 0 0 0-6.364.5.5 0 0 1 0-.707Z" />
+          <path d="M12.268 3.232a.5.5 0 0 1 .707 0 7.5 7.5 0 0 1 0 10.607.5.5 0 1 1-.707-.707 6.5 6.5 0 0 0 0-9.193.5.5 0 0 1 0-.707Z" />
         </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="mute-icon h-5 w-5 hidden"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM12.293 7.293a1 1 0 011.414 0L15 8.586l1.293-1.293a1 1 0 111.414 1.414L16.414 10l1.293 1.293a1 1 0 01-1.414 1.414L15 11.414l-1.293 1.293a1 1 0 01-1.414-1.414L13.586 10l-1.293-1.293a1 1 0 010-1.414z"
-            clip-rule="evenodd"></path>
+        <!-- Mute icon -->
+        <svg data-role="mute-icon" class="w-4 h-4 hidden" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M7.563 2.069A.75.75 0 0 1 8 2.75v10.5a.75.75 0 0 1-1.238.57L3.472 11H1.75A.75.75 0 0 1 1 10.25v-4.5A.75.75 0 0 1 1.75 5h1.722l3.29-2.82a.75.75 0 0 1 .801-.111Z" />
+          <path d="M11.354 5.354a.5.5 0 0 0-.708-.708L9 6.293 7.354 4.646a.5.5 0 1 0-.708.708L8.293 7 6.646 8.646a.5.5 0 1 0 .708.708L9 7.707l1.646 1.647a.5.5 0 0 0 .708-.708L9.707 7l1.647-1.646Z" />
         </svg>
       </button>
-      <div class="relative flex-grow max-w-[120px]">
-        <div
-          class="volume-container w-full h-1.5 bg-gray-200 rounded-full overflow-hidden"
-        >
-          <div id="volumeBar" class="volume-bar h-full bg-indigo-500 w-full">
-          </div>
+
+      <!-- Volume slider (hidden on small screens) -->
+      <div
+        data-role="volume-area"
+        class="hidden sm:block relative w-16 py-2 -my-2 cursor-pointer"
+        style="touch-action: none;"
+      >
+        <div class="h-1 bg-zinc-200 rounded-full overflow-hidden">
+          <div
+            data-role="volume-fill"
+            class="h-full bg-zinc-400 rounded-full transition-[width] duration-75"
+            style="width: 100%;"
+          ></div>
         </div>
-        <input
-          type="range"
-          id="volumeControl"
-          class="absolute top-0 w-full h-1.5 opacity-0 cursor-pointer"
-          min="0"
-          max="100"
-          value="100"
-        />
       </div>
     </div>
   </div>
-  <audio id="audioElement" src={src} preload="metadata" class="hidden"></audio>
+
+  <audio data-role="audio" src={src} preload="metadata" class="hidden"></audio>
 </div>
 
-<script define:vars={{ src }}>
-  function initAllAudioPlayers() {
-    const initAudioPlayer = (audioPlayerId) => {
-      // Find the closest parent component
-      const playerContainer = document
-        .querySelector(`[src="${src}"]`)
-        .closest(".audio-player");
-      if (!playerContainer) return;
+<script>
+  /**
+   * AudioPlayer — DD-principled audio player
+   *
+   * Applied DD principles:
+   * - Ergonomic interactions: generous hit areas, cursor affordance, focus rings
+   * - Responsive interfaces: real-time seek feedback, interpolated preview
+   * - Contained gestures: pointer capture for seek bar, cursor lock during drag
+   * - Simulating physics: press scale-down via CSS active:scale-90
+   * - Reduced responsiveness: no animation on time display updates (high-frequency)
+   */
+  function initAudioPlayers() {
+    document.querySelectorAll<HTMLElement>(".audio-player").forEach((root) => {
+      // Prevent double-init
+      if (root.dataset.init) return;
+      root.dataset.init = "1";
 
-      // Select elements
-      const audio = playerContainer.querySelector("#audioElement");
-      const playPauseBtn = playerContainer.querySelector("#playPauseBtn");
-      const progressBar = playerContainer.querySelector("#progressBar");
-      const seekBar = playerContainer.querySelector("#seekBar");
-      const currentTimeEl = playerContainer.querySelector("#currentTime");
-      const totalTimeEl = playerContainer.querySelector("#totalTime");
-      const muteBtn = playerContainer.querySelector("#muteBtn");
-      const volumeBar = playerContainer.querySelector("#volumeBar");
-      const volumeControl = playerContainer.querySelector("#volumeControl");
-      const playIcon = playerContainer.querySelector(".play-icon");
-      const pauseIcon = playerContainer.querySelector(".pause-icon");
-      const volumeIcon = playerContainer.querySelector(".volume-icon");
-      const muteIcon = playerContainer.querySelector(".mute-icon");
+      const $ = <T extends HTMLElement>(role: string) =>
+        root.querySelector<T>(`[data-role="${role}"]`)!;
 
-      // Format time in MM:SS
-      const formatTime = (seconds) => {
-        const mins = Math.floor(seconds / 60);
-        const secs = Math.floor(seconds % 60);
-        return `${mins}:${secs < 10 ? "0" : ""}${secs}`;
+      const audio = $<HTMLAudioElement>("audio");
+      const playPauseBtn = $("play-pause");
+      const playIcon = $("play-icon");
+      const pauseIcon = $("pause-icon");
+      const seekArea = $("seek-area");
+      const progressFill = $("progress-fill");
+      const seekThumb = $("seek-thumb");
+      const timePreview = $("time-preview");
+      const currentTimeEl = $("current-time");
+      const totalTimeEl = $("total-time");
+      const muteBtn = $("mute");
+      const volumeIcon = $("volume-icon");
+      const muteIcon = $("mute-icon");
+      const volumeArea = root.querySelector<HTMLElement>('[data-role="volume-area"]');
+      const volumeFill = root.querySelector<HTMLElement>('[data-role="volume-fill"]');
+
+      // --- Helpers ---
+      const fmt = (s: number) => {
+        if (!isFinite(s)) return "0:00";
+        const m = Math.floor(s / 60);
+        const sec = Math.floor(s % 60);
+        return `${m}:${sec < 10 ? "0" : ""}${sec}`;
       };
 
-      // Update progress bar and current time display
-      const updateProgress = () => {
-        const { currentTime, duration } = audio;
-        const progressPercent = (currentTime / duration) * 100;
-        progressBar.style.width = `${progressPercent}%`;
-        seekBar.value = progressPercent;
-        currentTimeEl.textContent = formatTime(currentTime);
+      const getProgress = () =>
+        audio.duration ? audio.currentTime / audio.duration : 0;
+
+      const setProgress = (pct: number) => {
+        progressFill.style.width = `${pct * 100}%`;
+        seekThumb.style.left = `${pct * 100}%`;
       };
 
-      // Set event listeners
-      audio.addEventListener("loadedmetadata", () => {
-        totalTimeEl.textContent = formatTime(audio.duration);
-        seekBar.max = 100;
-      });
+      // --- Shared icon sync ---
+      const syncMuteIcon = (muted: boolean) => {
+        volumeIcon.classList.toggle("hidden", muted);
+        muteIcon.classList.toggle("hidden", !muted);
+      };
 
-      audio.addEventListener("timeupdate", updateProgress);
-
-      audio.addEventListener("ended", () => {
-        playIcon.classList.remove("hidden");
-        pauseIcon.classList.add("hidden");
-      });
+      // --- Play / Pause ---
+      const updatePlayState = () => {
+        const playing = !audio.paused;
+        playIcon.classList.toggle("hidden", playing);
+        pauseIcon.classList.toggle("hidden", !playing);
+        playPauseBtn.setAttribute("aria-label", playing ? "Pause" : "Play");
+      };
 
       playPauseBtn.addEventListener("click", () => {
-        if (audio.paused) {
-          audio.play();
-          playIcon.classList.add("hidden");
-          pauseIcon.classList.remove("hidden");
-        } else {
-          audio.pause();
-          playIcon.classList.remove("hidden");
-          pauseIcon.classList.add("hidden");
+        if (audio.paused) audio.play();
+        else audio.pause();
+      });
+
+      audio.addEventListener("play", updatePlayState);
+      audio.addEventListener("pause", updatePlayState);
+      audio.addEventListener("ended", updatePlayState);
+
+      // --- Progress update (DD: reduced responsiveness — no animation on time) ---
+      audio.addEventListener("loadedmetadata", () => {
+        totalTimeEl.textContent = fmt(audio.duration);
+      });
+
+      audio.addEventListener("timeupdate", () => {
+        if (isSeeking) return; // Don't fight with seek gesture
+        const p = getProgress();
+        setProgress(p);
+        currentTimeEl.textContent = fmt(audio.currentTime);
+      });
+
+      // --- Seek gesture (DD: responsive gestures + contained gestures) ---
+      let isSeeking = false;
+
+      const seekFromEvent = (e: PointerEvent) => {
+        const rect = seekArea.getBoundingClientRect();
+        const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        audio.currentTime = pct * (audio.duration || 0);
+        setProgress(pct);
+        currentTimeEl.textContent = fmt(audio.currentTime);
+      };
+
+      const showPreviewAt = (e: PointerEvent) => {
+        const rect = seekArea.getBoundingClientRect();
+        const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        const time = pct * (audio.duration || 0);
+        timePreview.textContent = fmt(time);
+        timePreview.style.left = `${pct * 100}%`;
+        timePreview.style.opacity = "1";
+      };
+
+      // Hover preview (DD: responsive-interfaces — proportional feedback)
+      seekArea.addEventListener("pointerenter", () => {
+        seekThumb.style.opacity = "1";
+      });
+      seekArea.addEventListener("pointermove", (e: PointerEvent) => {
+        if (!isSeeking) showPreviewAt(e);
+      });
+      seekArea.addEventListener("pointerleave", () => {
+        if (!isSeeking) {
+          seekThumb.style.opacity = "0";
+          timePreview.style.opacity = "0";
         }
       });
 
-      seekBar.addEventListener("input", () => {
-        const seekTime = (seekBar.value / 100) * audio.duration;
-        audio.currentTime = seekTime;
+      // Seek start (DD: gesture lifecycle — start/move/end)
+      seekArea.addEventListener("pointerdown", (e: PointerEvent) => {
+        e.preventDefault();
+        isSeeking = true;
+        // DD: contained gestures — pointer capture
+        seekArea.setPointerCapture(e.pointerId);
+        seekThumb.style.opacity = "1";
+        // DD: contained gestures — cursor lock
+        document.body.style.cursor = "grabbing";
+        document.body.style.userSelect = "none";
+        seekFromEvent(e);
       });
 
-      muteBtn.addEventListener("click", () => {
-        audio.muted = !audio.muted;
-        volumeIcon.classList.toggle("hidden", audio.muted);
-        muteIcon.classList.toggle("hidden", !audio.muted);
-        volumeBar.style.width = audio.muted ? "0%" : `${volumeControl.value}%`;
+      seekArea.addEventListener("pointermove", (e: PointerEvent) => {
+        if (!isSeeking) return;
+        // DD: responsive gestures — real-time feedback on move
+        seekFromEvent(e);
+        showPreviewAt(e);
       });
 
-      volumeControl.addEventListener("input", () => {
-        const volume = volumeControl.value / 100;
-        audio.volume = volume;
-        volumeBar.style.width = `${volumeControl.value}%`;
-        audio.muted = volume === 0;
-        volumeIcon.classList.toggle("hidden", volume === 0);
-        muteIcon.classList.toggle("hidden", volume !== 0);
-      });
-    };
+      const endSeek = () => {
+        if (!isSeeking) return;
+        isSeeking = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        timePreview.style.opacity = "0";
+        if (!seekArea.matches(":hover")) {
+          seekThumb.style.opacity = "0";
+        }
+      };
 
-    // Initialize all audio players on the page
-    document.querySelectorAll(".audio-player").forEach((player, index) => {
-      initAudioPlayer(`audio-player-${index}`);
+      seekArea.addEventListener("pointerup", endSeek);
+      seekArea.addEventListener("pointercancel", endSeek);
+      // DD: pointer capture ensures lostpointercapture fires if pointer leaves
+      seekArea.addEventListener("lostpointercapture", endSeek);
+
+      // --- Volume ---
+      if (volumeArea && volumeFill) {
+        const setVolume = (pct: number) => {
+          audio.volume = pct;
+          volumeFill.style.width = `${pct * 100}%`;
+          audio.muted = pct === 0;
+          syncMuteIcon(pct === 0);
+        };
+
+        let isVolumeSeek = false;
+
+        const volumeFromEvent = (e: PointerEvent) => {
+          const rect = volumeArea.getBoundingClientRect();
+          const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+          setVolume(pct);
+        };
+
+        volumeArea.addEventListener("pointerdown", (e: PointerEvent) => {
+          e.preventDefault();
+          isVolumeSeek = true;
+          volumeArea.setPointerCapture(e.pointerId);
+          document.body.style.cursor = "grabbing";
+          volumeFromEvent(e);
+        });
+
+        volumeArea.addEventListener("pointermove", (e: PointerEvent) => {
+          if (isVolumeSeek) volumeFromEvent(e);
+        });
+
+        const endVolumeSeek = () => {
+          if (!isVolumeSeek) return;
+          isVolumeSeek = false;
+          document.body.style.cursor = "";
+        };
+
+        volumeArea.addEventListener("pointerup", endVolumeSeek);
+        volumeArea.addEventListener("pointercancel", endVolumeSeek);
+        volumeArea.addEventListener("lostpointercapture", endVolumeSeek);
+
+        muteBtn.addEventListener("click", () => {
+          audio.muted = !audio.muted;
+          syncMuteIcon(audio.muted);
+          volumeFill.style.width = audio.muted ? "0%" : `${audio.volume * 100}%`;
+        });
+      } else {
+        // Mobile: only mute toggle
+        muteBtn.addEventListener("click", () => {
+          audio.muted = !audio.muted;
+          syncMuteIcon(audio.muted);
+        });
+      }
+
+      // --- Keyboard (DD: responsive-interfaces — keyboard interactions) ---
+      // Arrow keys for seek when focused on player
+      root.addEventListener("keydown", (e: KeyboardEvent) => {
+        if (e.key === " " || e.key === "k") {
+          e.preventDefault();
+          if (audio.paused) audio.play();
+          else audio.pause();
+        } else if (e.key === "ArrowLeft") {
+          e.preventDefault();
+          audio.currentTime = Math.max(0, audio.currentTime - 5);
+        } else if (e.key === "ArrowRight") {
+          e.preventDefault();
+          audio.currentTime = Math.min(audio.duration, audio.currentTime + 5);
+        } else if (e.key === "m") {
+          e.preventDefault();
+          audio.muted = !audio.muted;
+          syncMuteIcon(audio.muted);
+          if (volumeFill) {
+            volumeFill.style.width = audio.muted ? "0%" : `${audio.volume * 100}%`;
+          }
+        }
+      });
+
+      // Make player focusable
+      root.setAttribute("tabindex", "0");
     });
   }
-  document.addEventListener("DOMContentLoaded", initAllAudioPlayers);
+
+  // Init on load and on Astro page transitions
+  document.addEventListener("DOMContentLoaded", initAudioPlayers);
+  document.addEventListener("astro:page-load", initAudioPlayers);
 </script>

--- a/src/components/embeds/LinkPreview.astro
+++ b/src/components/embeds/LinkPreview.astro
@@ -38,7 +38,8 @@ try {
     description ||
     extractMeta(html, "og:description") || extractMeta(html, "description") ||
     "No description available";
-  image = extractMeta(html, "og:image");
+  const rawImage = extractMeta(html, "og:image");
+  image = rawImage ? new URL(rawImage, src).href : null;
 } catch (error) {
   console.error(`Failed to fetch or parse ${src}:`, error);
   title = title || src;

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -2,6 +2,7 @@
 import Container from "./Container.astro";
 import Link from "./Link.astro";
 import HeaderClock from "../widget/HeaderClock";
+import ScrollProgressBar from "./ScrollProgressBar.astro";
 
 import { DEFAULT_LOCALE, LOCALE_LABELS } from "@consts";
 import { useTranslations } from "@i18n/utils";
@@ -52,6 +53,7 @@ const locales = Object.entries(LOCALE_LABELS);
       </nav>
     </div>
   </Container>
+  <ScrollProgressBar />
 </header>
 
 <style>

--- a/src/components/layout/ScrollProgressBar.astro
+++ b/src/components/layout/ScrollProgressBar.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * ScrollProgressBar — pure CSS scroll progress indicator.
+ * Uses CSS scroll-driven animations (animation-timeline: scroll())
+ * for zero-JS, GPU-accelerated performance.
+ *
+ * Place this component at the bottom of <header> so it renders
+ * as a thin bar right below the header.
+ */
+---
+
+<div class="scroll-progress-track" aria-hidden="true">
+  <div class="scroll-progress-bar"></div>
+</div>
+
+<style>
+  .scroll-progress-track {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    overflow: clip;
+    pointer-events: none;
+  }
+
+  .scroll-progress-bar {
+    height: 100%;
+    width: 100%;
+    background: #000;
+    transform-origin: left;
+    transform: scaleX(0);
+    animation: scroll-progress linear both;
+    animation-timeline: scroll();
+  }
+
+  @keyframes scroll-progress {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+
+  /* Fallback: hide on browsers that don't support scroll-driven animations */
+  @supports not (animation-timeline: scroll()) {
+    .scroll-progress-track {
+      display: none;
+    }
+  }
+</style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -158,7 +158,7 @@ const t = useTranslations(currentLocale as any);
     <article id="post-content" class="hyphens-auto break-words prose prose-black max-w-full prose-img:mx-auto prose-img:my-auto prose-headings:font-semibold prose-headings:text-black max-sm:text-sm max-sm:leading-7" style="font-family: 'Pretendard', 'Noto Sans JP', 'Oswald', 'Atkinson', sans-serif;">
       <Content />
     </article>
-    <ImageLightbox client:visible />
+    <ImageLightbox client:load />
     {
       seriesPosts.length > 1 && (
         <div class="animate text-zinc-500">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -7,6 +7,7 @@ import PostNavigation from "@components/blog/PostNavigation.astro";
 import CopyMenu from "@components/blog/CopyMenu.astro";
 import Share from "@components/blog/Share.astro";
 import TOC from "@components/blog/TOC.astro";
+import { ImageLightbox } from "@components/ImageLightbox";
 import { DEFAULT_LOCALE, OTHER_LOCALES } from "@consts";
 import { useTranslations } from "@i18n/utils";
 import PageLayout from "@layouts/PageLayout.astro";
@@ -161,6 +162,7 @@ const t = useTranslations(currentLocale as any);
     <article id="post-content" class="hyphens-auto break-words prose prose-black max-w-full prose-img:mx-auto prose-img:my-auto prose-headings:font-semibold prose-headings:text-black max-sm:text-sm max-sm:leading-7" style="font-family: 'Pretendard', 'Noto Sans JP', 'Oswald', 'Atkinson', sans-serif;">
       <Content />
     </article>
+    <ImageLightbox client:visible />
     {
       seriesPosts.length > 1 && (
         <div class="animate text-zinc-500">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -105,10 +105,6 @@ const t = useTranslations(currentLocale as any);
   webmcpCurrentLocale={currentLocale}
   availableLocales={availableLocales}
 >
-  <!--- Starts component --->
-  <div id="scroll-progress" class="bg-blue-600 h-1 fixed top-0 left-0 z-50">
-  </div>
-  <!--- Ends component --->
   <Container>
     <div>
       <BackToPrev href={t("path.blog")}>
@@ -188,15 +184,50 @@ const t = useTranslations(currentLocale as any);
     <Comments />
   </Container>
 </PageLayout>
-<!--- Starts script --->
-<script type="module">
-  window.addEventListener("scroll", function () {
-    const scrollableHeight =
-      document.documentElement.scrollHeight - window.innerHeight;
-    const scrolled = window.scrollY;
-    const progressBar = document.getElementById("scroll-progress");
-    const progress = (scrolled / scrollableHeight) * 100;
-    progressBar.style.width = progress + "%";
-  });
+
+<script>
+  /**
+   * Code block blur-fade scroll detection.
+   * Adds at-start / at-end / no-scroll classes to <pre> elements
+   * so mask-image gradients in global.css respond to scroll position.
+   */
+  function initCodeBlockBlurFade() {
+    const THRESHOLD = 2; // px tolerance for scroll boundary
+
+    function updateClasses(el: HTMLElement) {
+      const scrollable = el.scrollWidth > el.clientWidth + THRESHOLD;
+
+      if (!scrollable) {
+        el.classList.add("no-scroll");
+        el.classList.remove("at-start", "at-end");
+        return;
+      }
+
+      el.classList.remove("no-scroll");
+
+      const atStart = el.scrollLeft <= THRESHOLD;
+      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - THRESHOLD;
+
+      el.classList.toggle("at-start", atStart);
+      el.classList.toggle("at-end", atEnd);
+    }
+
+    const article = document.getElementById("post-content");
+    if (!article) return;
+
+    const pres = article.querySelectorAll<HTMLElement>("pre");
+
+    pres.forEach((pre) => {
+      updateClasses(pre);
+      pre.addEventListener("scroll", () => updateClasses(pre), { passive: true });
+    });
+
+    // Recalculate on resize (font size changes, viewport changes)
+    const ro = new ResizeObserver(() => {
+      pres.forEach((pre) => updateClasses(pre));
+    });
+    pres.forEach((pre) => ro.observe(pre));
+  }
+
+  document.addEventListener("DOMContentLoaded", initCodeBlockBlurFade);
 </script>
-<!--- Ends script --->

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,8 +1,8 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
 import PageLayout from "@layouts/PageLayout.astro";
-import ArrowCard from "@components/blog/ArrowCard.astro";
 import BlogSidebar from "@components/blog/BlogSidebar.astro";
+import AnimatedPostList from "@components/blog/AnimatedPostList.tsx";
 import { DEFAULT_LOCALE, SITE_DESCRIPTION, SITE_TITLE } from "@consts";
 
 const currentLocale = Astro.currentLocale || DEFAULT_LOCALE;
@@ -58,7 +58,25 @@ const posts = data.reduce((acc: Acc, post) => {
   return acc;
 }, {});
 
-const years = Object.keys(posts).sort((a, b) => parseInt(b) - parseInt(a));
+const sortedYears = Object.keys(posts).sort((a, b) => parseInt(b) - parseInt(a));
+
+// Serialize post data for React component (Date -> ISO string)
+const yearGroups = sortedYears.map((year) => ({
+  year,
+  posts: posts[year].map((post) => ({
+    id: post.id,
+    collection: post.collection,
+    data: {
+      title: post.data.title,
+      description: post.data.description,
+      date: post.data.date.toISOString(),
+      draft: post.data.draft,
+      categories: post.data.categories,
+    },
+  })),
+}));
+
+const isDev = import.meta.env.DEV;
 ---
 
 <PageLayout title={SITE_TITLE} description={SITE_DESCRIPTION}
@@ -67,24 +85,11 @@ const years = Object.keys(posts).sort((a, b) => parseInt(b) - parseInt(a));
     <div class="space-y-10">
       <div class="animate font-semibold text-black">블로그</div>
       <BlogSidebar categories={categories} series={series} locale="ko" />
-      <div class="space-y-4">
-        {
-          years.map((year) => (
-            <section class="animate space-y-4" data-year={year}>
-              <div class="font-semibold text-black">{year}</div>
-              <div>
-                <ul class="flex flex-col gap-4">
-                  {posts[year].map((post) => (
-                    <li data-categories={JSON.stringify(post.data.categories || [])}>
-                      <ArrowCard entry={post} />
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </section>
-          ))
-        }
-      </div>
+      <AnimatedPostList
+        client:visible
+        years={yearGroups}
+        isDev={isDev}
+      />
     </div>
   </div>
 </PageLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -281,6 +281,117 @@ footer {
   @apply bg-orange-500;
 }
 
+/* ==============================
+   Blur Fade Utilities
+   Inspired by Devouring Details' blur-fade component.
+   Uses mask-image gradients to softly fade edges of scrollable containers.
+   ============================== */
+
+/* Horizontal (left/right) blur fade — ideal for code blocks */
+.blur-fade-x {
+  --blur-fade-size: 24px;
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    black var(--blur-fade-size),
+    black calc(100% - var(--blur-fade-size)),
+    transparent
+  );
+}
+
+/* Vertical (top/bottom) blur fade */
+.blur-fade-y {
+  --blur-fade-size: 24px;
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    black var(--blur-fade-size),
+    black calc(100% - var(--blur-fade-size)),
+    transparent
+  );
+}
+
+/* All four sides blur fade */
+.blur-fade-all {
+  --blur-fade-size: 24px;
+  mask-image: linear-gradient(
+      to right,
+      transparent,
+      black var(--blur-fade-size),
+      black calc(100% - var(--blur-fade-size)),
+      transparent
+    ),
+    linear-gradient(
+      to bottom,
+      transparent,
+      black var(--blur-fade-size),
+      black calc(100% - var(--blur-fade-size)),
+      transparent
+    );
+  mask-composite: intersect;
+}
+
+/* Scroll-position-aware fade states:
+   When scrolled to the start, remove the left/top fade.
+   When scrolled to the end, remove the right/bottom fade. */
+.blur-fade-x.at-start {
+  mask-image: linear-gradient(
+    to right,
+    black,
+    black calc(100% - var(--blur-fade-size)),
+    transparent
+  );
+}
+
+.blur-fade-x.at-end {
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    black var(--blur-fade-size),
+    black
+  );
+}
+
+.blur-fade-x.at-start.at-end,
+.blur-fade-x.no-scroll {
+  mask-image: none;
+}
+
+/* Code block blur fade: auto-applied to pre elements within articles */
+article pre {
+  --blur-fade-size: 24px;
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    black var(--blur-fade-size),
+    black calc(100% - var(--blur-fade-size)),
+    transparent
+  );
+}
+
+article pre.at-start {
+  mask-image: linear-gradient(
+    to right,
+    black,
+    black calc(100% - var(--blur-fade-size)),
+    transparent
+  );
+}
+
+article pre.at-end {
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    black var(--blur-fade-size),
+    black
+  );
+}
+
+article pre.at-start.at-end,
+article pre.no-scroll {
+  mask-image: none;
+}
+
 /* Content Progressive Animation */
 @keyframes fadeInUp {
   from {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -258,8 +258,9 @@ footer {
   }
 
   img {
-    @apply rounded-lg shadow-xl hover:shadow-2xl hover:-translate-y-2 hover:scale-105 transition-all duration-300 ease-in-out !my-4;
+    @apply rounded-lg shadow-xl hover:shadow-2xl hover:scale-[1.01] transition-all duration-300 ease-in-out !my-4;
     color-scheme: only light;
+    cursor: zoom-in;
   }
 
   code {


### PR DESCRIPTION
## Summary
- **ImageLightbox**: reduced motion 지원, drag threshold 추가, dead code 정리, overlay opacity 단순화
- **AudioPlayer**: zinc 톤 미니멀 디자인으로 전면 재설계, pointer capture 기반 커스텀 seek/volume 슬라이더, 키보드 단축키(Space/K, 좌우 화살표, M), `syncMuteIcon` 헬퍼 추출
- **LinkPreview**: 상대 경로 `og:image` URL을 원본 도메인 기준으로 resolve (`new URL(rawImage, src)`)
- **blog slug page**: ImageLightbox `client:visible` → `client:load`

## Test plan
- [ ] 블로그 글에서 이미지 클릭 → 라이트박스 열림/드래그 dismiss 동작 확인
- [ ] prefers-reduced-motion 설정 시 애니메이션 스킵 확인
- [ ] AudioPlayer 재생/탐색/볼륨/키보드 동작 확인
- [ ] LinkPreview에서 ChatGPT 링크의 og:image가 정상 로드되는지 확인